### PR TITLE
Remove coffee extension

### DIFF
--- a/lib/remapify.js
+++ b/lib/remapify.js
@@ -47,7 +47,7 @@ module.exports = function(b, options){
         var filePath = path.resolve(g.cwd, file)
         // expose both with and with out the js extension to match normal npm behavior
         expandedAliases[path.join(pattern.expose || '', file)] = filePath
-        expandedAliases[path.join(pattern.expose || '', file.replace(/\.js$/, ''))] = filePath
+        expandedAliases[path.join(pattern.expose || '', file.replace(/\.(js|coffee)$/, ''))] = filePath
 
         log('found', file)
         b.emit('remapify:file', file, expandedAliases, g, pattern)


### PR DESCRIPTION
This PR allows you to reference coffee script files without the `.coffee` extension.
