### PR TITLE
adds filter option for filename tweaks

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ b.plugin(remapify, [
     src: './client/views/**/*.js' // glob for the files to remap
     , expose: 'views' // this will expose `__dirname + /client/views/home.js` as `views/home.js`
     , cwd: __dirname // defaults to process.cwd()
+    , filter: function(alias, dirname, basename) { // customize file names
+      return path.join(dirname, basename.replace('foo', 'bar'))
+    }
   }
 ])
 
@@ -58,6 +61,21 @@ Replace the `cwd` of each file in `src` with this value.
 
 #### `cwd` (optional)
 Specify the 'current working directory' for the glob pattern to start from and for the `expose` option to replace.
+
+#### `filter` (optional)
+Alter the file name on the fly. For example, if you wanted to require `_avatar.js` as `require('avatar')` you could do:
+
+```js
+var path = require('path')
+b.plugin(remapify, [
+  {
+    src: './**/*.js'
+    , filter: function(alias, dirname, basename) {
+      return path.join(dirname, basename.replace(/^\_(.*)\.js$/, '$1'))
+    }
+  }
+]);
+```
 
 #### glob options
 All options specified by the [glob](https://www.npmjs.org/package/glob) module can be used as well.

--- a/lib/remapify.js
+++ b/lib/remapify.js
@@ -66,6 +66,9 @@ module.exports = function(b, options){
         // if the file ext matches a known browserify extension, alias it, without the extensions
         if (aliasWithNoExt[1])
           expandedAliases[aliasWithNoExt[1]] = absoluteFilePath
+        // if the filter option is passed, call it with the alias and add it's result
+        if (pattern.filter)
+          expandedAliases[pattern.filter(alias, path.dirname(alias), path.basename(alias))] = absoluteFilePath
 
         log('found', absoluteFilePath)
         b.emit('remapify:file', absoluteFilePath, expandedAliases, g, pattern)

--- a/test/test.js
+++ b/test/test.js
@@ -156,11 +156,11 @@ describe('remapify', function(){
 
   it('works with absolute `cwd` paths', function(done){
     plugin(b, [{
-  	  src: './**/*.js'
-  	  , cwd: path.join(__dirname, 'fixtures/target')
-  	}])
+      src: './**/*.js'
+      , cwd: path.join(__dirname, 'fixtures/target')
+    }])
 
-  	b.on('remapify:files', function(files, expandedAliases){
+    b.on('remapify:files', function(files, expandedAliases){
       expandedAliases.should.contain.keys(
         'a.js'
         , 'b.js'
@@ -172,7 +172,7 @@ describe('remapify', function(){
       b.emit.should.not.have.been.calledWith('error')
 
       done()
-  	})
+    })
   })
 
   it('works with relative `cwd` paths', function(done){
@@ -208,6 +208,30 @@ describe('remapify', function(){
       setImmediate(function(){
         b.transform.should.have.been.calledOnce
       })
+    })
+  })
+
+  it('works with the filter option', function(done){
+    plugin(b, [{
+      src: './**/*.js'
+      , cwd: './test/fixtures/target'
+      , filter: function(alias, dirname, basename){
+        return path.join(dirname, '_' + basename)
+      }
+    }])
+
+    b.on('remapify:files', function(files, expandedAliases){
+      expandedAliases.should.contain.keys(
+        '_a.js'
+        , '_b.js'
+        , 'nested/_a.js'
+        , 'nested/_c.js'
+      )
+      expandedAliases['_a.js'].should.equal(path.resolve(__dirname, './fixtures/target/a.js'))
+
+      b.emit.should.not.have.been.calledWith('error')
+
+      done()
     })
   })
 


### PR DESCRIPTION
While working with browserify, I've found it useful to prefix files that I don't want being compiled with an underscore like `_avatar.js` or `_description.js` mentioned in your readme. However, I don't want to have to have the underscores in the require statements like `require('_avatar.js');`. I couldn't find a way to do this as of now, so I added an option with the task to tweak file names and add them to `expandedAliases`.

For example:

``` js
b.plugin(remapify, [
  {
    src: './**/*.js'
    , filter: function(fileName) {     // fileName is passed as something like `./foo-dir/_bar-file.js`
      return (/\/?((?:.(?!\/))+)$/)    // regex for everything after the last '/' in the file name
                .exec(fileName)[1]     // get file name from `exec` method
                .replace(/^\_/, '')    // replace leading underscore
                .replace(/\.js$/, ''); // replace file extension
    }
  }
]);
```

I played around with using the `remapify:file` event, but I felt like this was a cleaner way. What are your thoughts on this? Is there an easier way that I missed?
