### PR TITLE
fix for folders not containing any files but containing other folders

### DIFF
--- a/lib/remapify.js
+++ b/lib/remapify.js
@@ -65,7 +65,7 @@ module.exports = function(b, options){
         // if a folder doesn't contain any files
         // aliasWithNoExt is null
         // but might contains another folder
-        if (aliasWithNoExt && aliasWithNoExt.length > 1) {
+        if (aliasWithNoExt) {
 
           // expose both with and with out the js extension to match normal require behavior
           expandedAliases[alias] = aliasifyFilePath


### PR DESCRIPTION
When a folder doesn't contain any files, remapify throws an error as aliasWithNoExt is null.
Folders can be empty of files but can contains other folders (which won't be empty), especially if you're working on a package or library.
