### PR TITLE
#24 "Error: write after end" with browserify 7.x

### DIFF
--- a/lib/remapify.js
+++ b/lib/remapify.js
@@ -45,53 +45,54 @@ module.exports = function(b, options){
   }
 
   patterns.forEach(function(pattern){
-    var g = new Glob(pattern.src, pattern)
+    var g = new Glob(pattern.src, _.extend(pattern, {sync: true}))
       .on('error', function globError(err){
         log(err)
         b.emit('error', err)
       })
-      .on('match', function globMatch(file){
-        var processCwd = process.cwd()
-          , cwd = g.cwd || processCwd
-          // we'll send the process-relative path to aliasify
-          , aliasifyFilePath = './' + path.relative(process.cwd(), path.resolve(path.join(cwd, file)))
-          // we'll use the relative path to create our alias
-          , relativeFilePath = file.replace(cwd, '')
-          // append the expose path
-          , alias = path.join((pattern.expose || ''), relativeFilePath)
-          , extStripper = new RegExp('(.*?)(' + b._extensions.join('$|\\') + ')$')
-          , splittedPath = alias.split(path.sep)
+
+    g.found.forEach(function globMatch(file){
+      var processCwd = process.cwd()
+        , cwd = g.cwd || processCwd
+        // we'll send the process-relative path to aliasify
+        , aliasifyFilePath = './' + path.relative(process.cwd(), path.resolve(path.join(cwd, file)))
+        // we'll use the relative path to create our alias
+        , relativeFilePath = file.replace(cwd, '')
+        // append the expose path
+        , alias = path.join((pattern.expose || ''), relativeFilePath)
+        , extStripper = new RegExp('(.*?)(' + b._extensions.join('$|\\') + ')$')
+        , splittedPath = alias.split(path.sep)
 
       _(['/', '\\']).forEach(function(sep){
-          var alias = splittedPath.join(sep)
-            , aliasWithNoExt = alias.match(extStripper);
-          // expose both with and with out the js extension to match normal require behavior
-          expandedAliases[alias] = aliasifyFilePath
-          // if the file ext matches a known browserify extension, alias it, without the extensions
-          if (aliasWithNoExt[1])
-            expandedAliases[aliasWithNoExt[1]] = aliasifyFilePath
-          // if the filter option is passed, call it with the alias and add it's result
-          if (pattern.filter){
-            if (sep === path.sep)
-              expandedAliases[pattern.filter(alias, path.dirname(alias), path.basename(alias))] = aliasifyFilePath
-            else {
-              var lastIndex = alias.lastIndexOf(sep)
-              if (lastIndex < 0)
-                expandedAliases[pattern.filter(alias, '.', alias).split(path.sep).join(sep)] = aliasifyFilePath
-              else
-                expandedAliases[pattern.filter(alias
-                  , alias.substring(0, lastIndex)
-                  , alias.substring(lastIndex + 1)).split(path.sep).join(sep)] = aliasifyFilePath
-            }
+        var alias = splittedPath.join(sep)
+          , aliasWithNoExt = alias.match(extStripper);
+        // expose both with and with out the js extension to match normal require behavior
+        expandedAliases[alias] = aliasifyFilePath
+        // if the file ext matches a known browserify extension, alias it, without the extensions
+        if (aliasWithNoExt[1])
+          expandedAliases[aliasWithNoExt[1]] = aliasifyFilePath
+        // if the filter option is passed, call it with the alias and add it's result
+        if (pattern.filter){
+          if (sep === path.sep)
+            expandedAliases[pattern.filter(alias, path.dirname(alias), path.basename(alias))] = aliasifyFilePath
+          else {
+            var lastIndex = alias.lastIndexOf(sep)
+            if (lastIndex < 0)
+              expandedAliases[pattern.filter(alias, '.', alias).split(path.sep).join(sep)] = aliasifyFilePath
+            else
+              expandedAliases[pattern.filter(alias
+                , alias.substring(0, lastIndex)
+                , alias.substring(lastIndex + 1)).split(path.sep).join(sep)] = aliasifyFilePath
           }
-        })
+        }
+      })
 
-        log('found', aliasifyFilePath)
-        b.emit('remapify:file', aliasifyFilePath, expandedAliases, g, pattern)
-      })
-      .on('end', function globEnd(files){
-        b.emit('remapify:files', files, expandedAliases, g, pattern)
-        done()
-      })
+      log('found', aliasifyFilePath)
+      b.emit('remapify:file', aliasifyFilePath, expandedAliases, g, pattern)
+    })
+    // globMatch
+
+    b.emit('remapify:files', g.found, expandedAliases, g, pattern)
+    done()
   })
 }

--- a/test/test.js
+++ b/test/test.js
@@ -32,7 +32,6 @@ describe('remapify', function(){
 
   it('gets all the files from a glob pattern', function(done){
     should.exist(b)
-    plugin(b, [{src: './test/fixtures/target/**/*.js', expose: 'path'}])
 
     b.on('remapify:files', function(files){
       files.should.deep.equal(
@@ -46,15 +45,11 @@ describe('remapify', function(){
 
       done()
     })
+
+    plugin(b, [{src: './test/fixtures/target/**/*.js', expose: 'path'}])
   })
 
   it('works with the `cwd` option', function(done){
-    plugin(b, [{
-      src: './fixtures/target/**/*.js'
-      , expose: 'path'
-      , cwd: './test'
-    }])
-
     b.on('remapify:files', function(files){
       files.should.deep.equal(
         ['./fixtures/target/a.js'
@@ -67,15 +62,15 @@ describe('remapify', function(){
 
       done()
     })
+
+    plugin(b, [{
+      src: './fixtures/target/**/*.js'
+      , expose: 'path'
+      , cwd: './test'
+    }])
   })
 
   it('exposes the files under a different alias', function(done){
-    plugin(b, [{
-      src: './**/*.js'
-      , expose: 'path'
-      , cwd: './test/fixtures/target'
-    }])
-
     b.on('remapify:files', function(files, expandedAliases){
       expandedAliases.should.contain.keys(
         'path/a.js'
@@ -95,14 +90,15 @@ describe('remapify', function(){
 
       done()
     })
+
+    plugin(b, [{
+      src: './**/*.js'
+      , expose: 'path'
+      , cwd: './test/fixtures/target'
+    }])
   })
 
   it('works without the expose option', function(done){
-    plugin(b, [{
-      src: './**/*.js'
-      , cwd: './test/fixtures/target'
-    }])
-
     b.on('remapify:files', function(files, expandedAliases){
       expandedAliases.should.contain.keys(
         'a.js'
@@ -118,14 +114,14 @@ describe('remapify', function(){
 
       done()
     })
+
+    plugin(b, [{
+      src: './**/*.js'
+      , cwd: './test/fixtures/target'
+    }])
   })
 
   it('aliases with and without the `.js` extension', function(done){
-    plugin(b, [{
-      src: '**/*.js'
-      , cwd: './test/fixtures/target'
-    }])
-
     b.on('remapify:files', function(files, expandedAliases){
       expandedAliases.should.contain.keys(
         'a.js'
@@ -138,16 +134,16 @@ describe('remapify', function(){
 
       done()
     })
+
+    plugin(b, [{
+      src: '**/*.js'
+      , cwd: './test/fixtures/target'
+    }])
   })
 
   it('works with non-standard extensions', function(done){
     // setup
     b._extensions = b._extensions.concat('.coffee')
-
-    plugin(b, [{
-      src: '**/*.coffee'
-      , cwd: './test/fixtures/target'
-    }])
 
     b.on('remapify:files', function(files, expandedAliases){
       expandedAliases.should.contain.keys(
@@ -163,37 +159,37 @@ describe('remapify', function(){
       b._extensions.pop()
       done()
     })
+
+    plugin(b, [{
+      src: '**/*.coffee'
+      , cwd: './test/fixtures/target'
+    }])
   })
 
   it('works with absolute `cwd` paths', function(done){
+    b.on('remapify:files', function(files, expandedAliases){
+      expandedAliases.should.contain.keys(
+        'a.js'
+        , 'b.js'
+        , 'nested/a.js'
+        , 'nested/c.js'
+        , 'nested\\a.js'
+        , 'nested\\c.js'
+      )
+      expandedAliases['a.js'].split(path.sep).join('/').should.equal('./test/fixtures/target/a.js')
+
+      b.emit.should.not.have.been.calledWith('error')
+
+      done()
+    })
+
     plugin(b, [{
       src: './**/*.js'
       , cwd: path.join(__dirname, 'fixtures/target')
     }])
-
-    b.on('remapify:files', function(files, expandedAliases){
-      expandedAliases.should.contain.keys(
-        'a.js'
-        , 'b.js'
-        , 'nested/a.js'
-        , 'nested/c.js'
-        , 'nested\\a.js'
-        , 'nested\\c.js'
-      )
-      expandedAliases['a.js'].split(path.sep).join('/').should.equal('./test/fixtures/target/a.js')
-
-      b.emit.should.not.have.been.calledWith('error')
-
-      done()
-    })
   })
 
   it('works with relative `cwd` paths', function(done){
-    plugin(b, [{
-      src: './**/*.js'
-      , cwd: './test/fixtures/target'
-    }])
-
     b.on('remapify:files', function(files, expandedAliases){
       expandedAliases.should.contain.keys(
         'a.js'
@@ -209,15 +205,14 @@ describe('remapify', function(){
 
       done()
     })
+
+    plugin(b, [{
+      src: './**/*.js'
+      , cwd: './test/fixtures/target'
+    }])
   })
 
   it('calls `b.transform` on all expanded aliases', function(done){
-    plugin(b, [{
-      src: './**/*.js'
-      , expose: 'path'
-      , cwd: './test/fixtures/target'
-    }])
-
     b.on('remapify:files', function(){
       // wait for the callstack to clear since the event is triggered before b.transform is called.
       setImmediate(function(){
@@ -225,17 +220,15 @@ describe('remapify', function(){
         done()
       })
     })
+
+    plugin(b, [{
+      src: './**/*.js'
+      , expose: 'path'
+      , cwd: './test/fixtures/target'
+    }])
   })
 
   it('works with the filter option', function(done){
-    plugin(b, [{
-      src: './**/*.js'
-      , cwd: './test/fixtures/target'
-      , filter: function(alias, dirname, basename){
-        return path.join(dirname, '_' + basename)
-      }
-    }])
-
     b.on('remapify:files', function(files, expandedAliases){
       expandedAliases.should.contain.keys(
         '_a.js'
@@ -251,6 +244,14 @@ describe('remapify', function(){
 
       done()
     })
+
+    plugin(b, [{
+      src: './**/*.js'
+      , cwd: './test/fixtures/target'
+      , filter: function(alias, dirname, basename){
+        return path.join(dirname, '_' + basename)
+      }
+    }])
   })
 
 })


### PR DESCRIPTION
This is meant to fix #24. I don't know how browserify < 7 worked, but it seems that in >= 7 its pipeline can finish before remapify's globbing and addition of the aliasify transform finishes. I think it's necessary to do the globbing synchronously. This PR makes the globbing synchronous and adjusts the code consuming the glob results accordingly. `globMatch()` is exactly the same -- it's just passed to a different method and its indentation level changed.

I haven't added any new tests (not yet anyway). After a slight adjustment, all of the existing tests pass. Each test followed a sequence of 1) run plugin, 2) register event handler. I had to swap the sequence because remapify was emitting events before handlers were registered. (I suggest diffing that commit with `--patience`.)

I haven't tested this extensively, but with a simple trial it works with browserify 6-8, and like I said the tests pass.

I did try retaining the asynchronous globbing and utilizing streams to make everything work, but I couldn't work that out.