### PR TITLE
Set aliasify `configDir` to correct value.

### DIFF
--- a/lib/remapify.js
+++ b/lib/remapify.js
@@ -24,6 +24,7 @@ module.exports = function remapify(b, options){
     , doneAfterCount = patterns.length
     , doneCount = 0
     , done
+    , processCwd = process.cwd()
 
   done = function done(pattern){
     var expandedAliasesCount
@@ -37,7 +38,7 @@ module.exports = function remapify(b, options){
       log('exposing ' + expandedAliasesCount + ' aliases.')
       b.transform(aliasify.configure({
         aliases: expandedAliases
-        , configDir: process.cwd()
+        , configDir: processCwd
       }))
     }
     else {
@@ -52,10 +53,9 @@ module.exports = function remapify(b, options){
         b.emit('error', err)
       })
       .on('match', function globMatch(file){
-        var processCwd = process.cwd()
-          , cwd = g.cwd || processCwd
+        var cwd = g.cwd || processCwd
           // we'll send the process-relative path to aliasify
-          , aliasifyFilePath = './' + path.relative(process.cwd(), path.resolve(path.join(cwd, file)))
+          , aliasifyFilePath = './' + path.relative(processCwd, path.resolve(path.join(cwd, file)))
           // we'll use the relative path to create our alias
           , relativeFilePath = file.replace(cwd, '')
           // append the expose path

--- a/lib/remapify.js
+++ b/lib/remapify.js
@@ -37,7 +37,7 @@ module.exports = function remapify(b, options){
       log('exposing ' + expandedAliasesCount + ' aliases.')
       b.transform(aliasify.configure({
         aliases: expandedAliases
-        , configDir: pattern.cwd
+        , configDir: process.cwd()
       }))
     }
     else {


### PR DESCRIPTION
This fixes the problem illustrated in [this example](https://github.com/joeybaker/remapify/issues/23#issuecomment-69796546).

remapify is aggregating aliases from all of the patterns, and pointing the aliases to paths relative to `process.cwd()`, but then passing the `src` from *one* of the patterns to aliasify as `configDir`. To do things the way the plugin is setup to do them, all of the paths the aliases point to need to be relative to the same dir that's passed as aliasify's `configDir`.

The tests continue to pass after this change, but they also passed before the change when this was broken. How do you suggest going about testing that remapify generates the correct data and configuration for aliasify?
