### PR TITLE
Reapply our alias map if the underlying browserify pipeline is reset.

### DIFF
--- a/lib/remapify.js
+++ b/lib/remapify.js
@@ -55,6 +55,10 @@ transformAliases = function transformAliases(b, results){
     // months trying to figure out the browserify pipeline to work and… sqaut.
     // so, this works. Fuck it.
     _.defaults(b._mdeps.options.modules, aliasMap)
+    b.on('reset', function() {
+      // reapply if browserify pipeline is recreated (e.g. in watchify)
+      _.defaults(b._mdeps.options.modules, aliasMap)
+    })
   }
   else {
     log('no aliases found to expose.')


### PR DESCRIPTION
I had the same problem as #38, using watchify and remapify together in a gulp task.

I traced the issue to the aliasMap being lost when the underlying browserify was reset.

This fix simply listens for that event and reapplies the aliasMap.